### PR TITLE
Enh #61: Only use _blank on external richtext links

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -21,6 +21,7 @@ Changelog
 - Fix #32: Disallow marks in code block schema
 - Fix #41: Overflow detection broken
 - Fix #36: resize nav state does not respect selection state
+- Enh #61: Only use _blank on external richtext links (https://github.com/humhub/humhub/issues/3989)
 
 
 1.1.2 (February 18, 2021)

--- a/src/editor/core/plugins/link/index.js
+++ b/src/editor/core/plugins/link/index.js
@@ -41,7 +41,11 @@ const link = {
             var aIndex = tokens[idx].attrIndex('target');
 
             if (aIndex < 0) {
-                tokens[idx].attrPush(['target', '_blank']); // add new attribute
+                // Check if the link is external
+                var hrefUrl = new URL(tokens[idx].attrs[hrefIndex][1]);
+                if (hrefUrl.hostname !== window.location.hostname) {
+                    tokens[idx].attrPush(['target', '_blank']); // add new attribute
+                }
             } else if(!tokens[idx].attrs[aIndex][1]) {
                 tokens[idx].attrs[aIndex][1] = '_blank';    // replace value of existing attr
             }


### PR DESCRIPTION
https://github.com/humhub/humhub-prosemirror/issues/61
and https://github.com/humhub/humhub/issues/3989